### PR TITLE
feat: add support for experimentations

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://drive.google.com/drive/u/3/folders/1ICFXi4F2TuLbD1ELzZW1J_s1juCvspdR
+  /: https://drive.google.com/drive/u/1/folders/1ICFXi4F2TuLbD1ELzZW1J_s1juCvspdR

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://drive.google.com/drive/u/1/folders/1ICFXi4F2TuLbD1ELzZW1J_s1juCvspdR
+  /: https://drive.google.com/drive/folders/1ICFXi4F2TuLbD1ELzZW1J_s1juCvspdR

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://drive.google.com/drive/u/1/folders/1ICFXi4F2TuLbD1ELzZW1J_s1juCvspdR
+  /: https://drive.google.com/drive/u/3/folders/1ICFXi4F2TuLbD1ELzZW1J_s1juCvspdR

--- a/scripts/experiment-preview.js
+++ b/scripts/experiment-preview.js
@@ -28,6 +28,7 @@ const createVariant = (variantName, config) => {
   // this will retain other query params such as ?rum=on
   experimentURL.searchParams.set('experiment', `${config.id}/${variantName}`);
 
+  div.id = variantName;
   div.className = `hlx-variant${config.selectedVariant === variantName ? ' hlx-variant-selected' : ' '}`;
   div.innerHTML = `<div>
   <h5>${variantName}</h5>
@@ -39,47 +40,72 @@ const createVariant = (variantName, config) => {
   return (div);
 };
 
+function getExperimentVariantPopup(config) {
+  const popup = document.createElement('div');
+  popup.className = 'hlx-experiment hlx-popup hlx-hidden';
+  popup.innerHTML = `
+    <div class="hlx-popup-header">
+      <div>
+        <h4>${config.experimentName}</h4>
+        <div class="hlx-details">${config.status}, ${config.audience}</div>
+      </div>
+      <div>
+        <div class="hlx-button"><a href="${config.manifest}">Manifest</a></div>
+      </div>
+    </div>
+    <div class="hlx-variants"></div>`;
+
+  const variants = popup.querySelector('.hlx-variants');
+  config.variantNames.forEach((vname) => {
+    const variantDiv = createVariant(vname, config);
+    variants.append(variantDiv);
+  });
+  return popup;
+}
+
+function getExperimentVariantSelectorInSidekick(config) {
+  const div = document.createElement('div');
+  div.className = 'experiment dropdown';
+
+  const button = document.createElement('button');
+  button.className = 'dropdown-toggle';
+  button.innerHTML = 'Experiment';
+  if (toClassName(config.status) === 'active') {
+    button.style.backgroundColor = '#280';
+  }
+  div.append(button);
+
+  const container = document.querySelector('helix-sidekick').shadowRoot.querySelector('.feature-container');
+  container.prepend(div);
+
+  return div;
+}
+
 /**
  * Create Badge if a Page is enlisted in a Helix Experiment
  * @return {Object} returns a badge or empty string
  */
-async function getExperimentVariantSelector() {
-  const experiment = toClassName(getMetadata('experiment'));
-  if (!experiment) {
-    return null;
-  }
+function getExperimentVariantSelectorInOverlay(config) {
+  const button = document.createElement('button');
+  button.className = 'hlx-experiment hlx-badge';
+  button.classList.add(`hlx-experiment-status-${toClassName(config.status)}`);
+  button.innerHTML = 'Experiment <span class="hlx-open"></span>';
+  return button;
+}
 
-  const config = window.hlx && window.hlx.experiment;
-  if (!config) {
-    return null;
-  }
-
-  const div = document.createElement('div');
-  div.className = 'hlx-experiment hlx-badge';
-  div.classList.add(`hlx-experiment-status-${toClassName(config.status)}`);
-  div.innerHTML = `Experiment <span class="hlx-open"></span>
-    <div class="hlx-popup hlx-hidden">
-      <div class="hlx-popup-header">
-        <div>
-          <h4>${config.experimentName}</h4>
-          <div class="hlx-details">${config.status}, ${config.audience}</div>
-        </div>
-        <div>
-          <div class="hlx-button"><a href="${config.manifest}">Manifest</a></div>
-        </div>
-      </div>
-      <div class="hlx-variants"></div>
-    </div>`;
-  const popup = div.querySelector('.hlx-popup');
-
-  const variantMap = {};
-
-  div.addEventListener('click', async () => {
+function registerClickHandler(button, popup, config) {
+  button.addEventListener('click', async () => {
     popup.classList.toggle('hlx-hidden');
+
+    const sidekick = document.querySelector('helix-sidekick');
+    if (sidekick) {
+      const { x, width } = button.getBoundingClientRect();
+      popup.style.right = `${window.innerWidth - x - width - 40}px`;
+    }
 
     // the query is a bit slow, so I'm only fetching the results when the popup is opened
     const resultsURL = new URL('https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments');
-    resultsURL.searchParams.set('experiment', experiment);
+    resultsURL.searchParams.set('experiment', config.experimentName);
     if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
       // restrict results to the production host, this also reduces query cost
       resultsURL.searchParams.set('domain', window.hlx.sidekickConfig.host);
@@ -90,7 +116,7 @@ async function getExperimentVariantSelector() {
       const nf = {
         format: (num) => `${Math.floor(num)}%`,
       };
-      const variant = variantMap[result.variant];
+      const variant = document.querySelector(`#${result.variant}`);
       if (variant) {
         const performance = variant.querySelector('.performance');
         performance.innerHTML = `
@@ -101,32 +127,41 @@ async function getExperimentVariantSelector() {
       }
     });
   });
-
-  const variants = div.querySelector('.hlx-variants');
-  config.variantNames.forEach((vname) => {
-    const variantDiv = createVariant(vname, config);
-    variants.append(variantDiv);
-    variantMap[vname] = variantDiv;
-  });
-
-  return div;
 }
 
 async function createPreviewOverlay() {
+  const experiment = toClassName(getMetadata('experiment'));
+  if (!experiment) {
+    return;
+  }
+
+  const config = window.hlx && window.hlx.experiment;
+  if (!config) {
+    return;
+  }
+
   const sidekick = document.querySelector('helix-sidekick');
 
   loadCSS('/styles/experiment-preview.css');
   const overlay = document.createElement('div');
   overlay.className = 'hlx-preview-overlay';
 
-  if (sidekick) {
-    overlay.classList.add('hlx-preview-overlay-sidekick');
+  const popup = getExperimentVariantPopup(config);
+  const button = sidekick
+    ? getExperimentVariantSelectorInSidekick(config)
+    : getExperimentVariantSelectorInOverlay(config);
+
+  if (!button || !popup) {
+    return;
   }
 
-  const variantSelector = await getExperimentVariantSelector();
-  if (variantSelector) {
-    overlay.append(variantSelector);
+  registerClickHandler(button, popup, config);
+  if (!sidekick) {
+    overlay.append(button);
+  } else {
+    overlay.classList.add('hlx-preview-overlay-sidekick');
   }
+  overlay.append(popup);
 
   document.body.append(overlay);
 }

--- a/scripts/experiment-preview.js
+++ b/scripts/experiment-preview.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  loadCSS,
+  toClassName,
+  getMetadata,
+} from './scripts.js';
+
+const createVariant = (variantName, config) => {
+  const variant = config.variants[variantName];
+  const split = +variant.percentageSplit
+    || 1 - config.variantNames.reduce((c, vn) => c + +config.variants[vn].percentageSplit, 0);
+  const percentage = Math.round(split * 10000) / 100;
+  const div = document.createElement('div');
+
+  const experimentURL = new URL(window.location.href);
+  // this will retain other query params such as ?rum=on
+  experimentURL.searchParams.set('experiment', `${config.id}/${variantName}`);
+
+  div.className = `hlx-variant${config.selectedVariant === variantName ? ' hlx-variant-selected' : ' '}`;
+  div.innerHTML = `<div>
+  <h5>${variantName}</h5>
+    <p>${variant.label}</p>
+    <p>${percentage}%</p>
+    <p class="performance"></p>
+  </div>
+  <div class="hlx-button"><a href="${experimentURL.href}">Simulate</a></div>`;
+  return (div);
+};
+
+/**
+ * Create Badge if a Page is enlisted in a Helix Experiment
+ * @return {Object} returns a badge or empty string
+ */
+async function getExperimentVariantSelector() {
+  const experiment = toClassName(getMetadata('experiment'));
+  if (!experiment) {
+    return null;
+  }
+
+  const config = window.hlx && window.hlx.experiment;
+  if (!config) {
+    return null;
+  }
+
+  const div = document.createElement('div');
+  div.className = 'hlx-experiment hlx-badge';
+  div.classList.add(`hlx-experiment-status-${toClassName(config.status)}`);
+  div.innerHTML = `Experiment <span class="hlx-open"></span>
+    <div class="hlx-popup hlx-hidden">
+      <div class="hlx-popup-header">
+        <div>
+          <h4>${config.experimentName}</h4>
+          <div class="hlx-details">${config.status}, ${config.audience}</div>
+        </div>
+        <div>
+          <div class="hlx-button"><a href="${config.manifest}">Manifest</a></div>
+        </div>
+      </div>
+      <div class="hlx-variants"></div>
+    </div>`;
+  const popup = div.querySelector('.hlx-popup');
+
+  const variantMap = {};
+
+  div.addEventListener('click', async () => {
+    popup.classList.toggle('hlx-hidden');
+
+    // the query is a bit slow, so I'm only fetching the results when the popup is opened
+    const resultsURL = new URL('https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments');
+    resultsURL.searchParams.set('experiment', experiment);
+    if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
+      // restrict results to the production host, this also reduces query cost
+      resultsURL.searchParams.set('domain', window.hlx.sidekickConfig.host);
+    }
+    const resp = await fetch(resultsURL.href);
+    const { results } = await resp.json();
+    results.forEach((result) => {
+      const nf = {
+        format: (num) => `${Math.floor(num)}%`,
+      };
+      const variant = variantMap[result.variant];
+      if (variant) {
+        const performance = variant.querySelector('.performance');
+        performance.innerHTML = `
+          <span>click rate: ${nf.format(100 * Number.parseFloat(result.variant_conversion_rate))}</span>
+          <span>vs. ${nf.format(100 * Number.parseFloat(result.control_conversion_rate))}</span>
+          <span>significance: ${nf.format(100 * Number.parseFloat(result.p_value))}</span> <!-- everything below 95% is not good enough for the social sciences to be considered significant --->
+        `;
+      }
+    });
+  });
+
+  const variants = div.querySelector('.hlx-variants');
+  config.variantNames.forEach((vname) => {
+    const variantDiv = createVariant(vname, config);
+    variants.append(variantDiv);
+    variantMap[vname] = variantDiv;
+  });
+
+  return div;
+}
+
+async function createPreviewOverlay() {
+  const sidekick = document.querySelector('helix-sidekick');
+
+  loadCSS('/styles/experiment-preview.css');
+  const overlay = document.createElement('div');
+  overlay.className = 'hlx-preview-overlay';
+
+  if (sidekick) {
+    overlay.classList.add('hlx-preview-overlay--sidekick');
+  }
+
+  const variantSelector = await getExperimentVariantSelector();
+  if (variantSelector) {
+    overlay.append(variantSelector);
+  }
+
+  document.body.append(overlay);
+}
+
+try {
+  createPreviewOverlay();
+} catch (e) {
+  console.log(e);
+}

--- a/scripts/experiment-preview.js
+++ b/scripts/experiment-preview.js
@@ -142,25 +142,31 @@ async function createPreviewOverlay() {
 
   const sidekick = document.querySelector('helix-sidekick');
 
-  loadCSS('/styles/experiment-preview.css');
+  loadCSS(`${window.hlx.codeBasePath}/styles/experiment-preview.css`);
   const overlay = document.createElement('div');
   overlay.className = 'hlx-preview-overlay';
 
   const popup = getExperimentVariantPopup(config);
-  const button = sidekick
-    ? getExperimentVariantSelectorInSidekick(config)
-    : getExperimentVariantSelectorInOverlay(config);
+  const overlayButton = getExperimentVariantSelectorInOverlay(config);
 
-  if (!button || !popup) {
-    return;
-  }
-
-  registerClickHandler(button, popup, config);
-  if (!sidekick) {
-    overlay.append(button);
-  } else {
+  registerClickHandler(overlayButton, popup, config);
+  if (sidekick) {
+    const sidekickInner = sidekick.shadowRoot.querySelector('.hlx-sk');
+    const sidekickButton = getExperimentVariantSelectorInSidekick(config);
+    registerClickHandler(sidekickButton, popup, config);
     overlay.classList.add('hlx-preview-overlay-sidekick');
+    overlayButton.classList.toggle('hlx-hidden', !sidekickInner.classList.contains('hlx-sk-hidden'));
+    const attrObserver = new MutationObserver((mutations) => {
+      mutations.forEach((m) => {
+        if (m.type === 'attributes' && m.attributeName === 'class') {
+          overlay.classList.toggle('hlx-preview-overlay-sidekick', !m.target.classList.contains('hlx-sk-hidden'));
+          overlayButton.classList.toggle('hlx-hidden', !sidekickInner.classList.contains('hlx-sk-hidden'));
+        }
+      });
+    });
+    attrObserver.observe(sidekickInner, { attributes: true });
   }
+  overlay.append(overlayButton);
   overlay.append(popup);
 
   document.body.append(overlay);

--- a/scripts/experiment-preview.js
+++ b/scripts/experiment-preview.js
@@ -9,7 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
+/* eslint-disable no-console */
+// eslint-disable-next-line import/no-cycle
 import {
   loadCSS,
   toClassName,
@@ -119,7 +120,7 @@ async function createPreviewOverlay() {
   overlay.className = 'hlx-preview-overlay';
 
   if (sidekick) {
-    overlay.classList.add('hlx-preview-overlay--sidekick');
+    overlay.classList.add('hlx-preview-overlay-sidekick');
   }
 
   const variantSelector = await getExperimentVariantSelector();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -710,7 +710,6 @@ function getRandomVariant(config) {
 
     const currentPath = window.location.pathname;
     const pageIndex = config.variants[config.variantNames[0]].pages.indexOf(currentPath);
-    console.debug(pageIndex, config.variants[config.variantNames[0]].pages, currentPath);
     if (pageIndex < 0) {
       return;
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -807,6 +807,10 @@ async function loadPage(doc) {
   await loadLazy(doc);
   // eslint-disable-next-line no-use-before-define
   loadDelayed(doc);
+
+  if (window.location.hostname.endsWith('hlx.page') || window.location.hostname === ('localhost')) {
+    import('./experiment-preview.js');
+  }
 }
 
 export function initHlx() {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -492,9 +492,9 @@ function decorateTemplateAndTheme() {
  */
  export function getExperiment() {
   // Non-prod website get default content
-  if (!window.location.host.includes('.hlx.live')) {
-    return null;
-  }
+  // if (!window.location.host.includes('.hlx.live')) {
+  //   return null;
+  // }
   // Anchor links get default content
   if (window.location.hash) {
     return null;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -524,7 +524,7 @@ export function parseExperimentConfig(json) {
     json.settings.data.forEach((row) => {
       config[toCamelCase(row.Name)] = row.Value;
     });
-    
+
     config.variantNames = [];
     config.variants = {};
     json.experiences.data.forEach((row) => {
@@ -534,11 +534,11 @@ export function parseExperimentConfig(json) {
         percentageSplit: row.Split,
         pages: [new URL(row.Page.trim()).pathname],
         label: row.Label,
-      }
+      };
     });
     return config;
   } catch (e) {
-    console.log(`error loading experiment manifest: ${path}`, e);
+    console.log('error parsing experiment config:', e);
   }
   return null;
 }
@@ -564,7 +564,7 @@ export async function getExperimentConfig(experimentId) {
   try {
     const resp = await fetch(path);
     if (!resp.ok) {
-      console.log(`error loading experiment config:`, resp);
+      console.log('error loading experiment config:', resp);
       return null;
     }
     const json = await resp.json();
@@ -654,8 +654,8 @@ async function replaceInner(path, element) {
   try {
     const resp = await fetch(plainPath);
     if (!resp.ok) {
-      console.log(`error loading experiment content:`, resp);
-      return;
+      console.log('error loading experiment content:', resp);
+      return null;
     }
     const html = await resp.text();
     element.innerHTML = html;
@@ -678,7 +678,7 @@ async function decorateExperiment() {
     const usp = new URLSearchParams(window.location.search);
     const [forcedExperiment, forcedVariant] = usp.has('experiment') ? usp.get('experiment').split('/') : [];
     console.debug('experiment', forcedExperiment || experiment, forcedVariant || '');
-    
+
     const config = await getExperimentConfig(experiment);
     console.debug(config);
     if (toCamelCase(config.status) !== 'active' && !forcedExperiment) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -533,7 +533,7 @@ export function parseExperimentConfig(json) {
       config.variantNames.push(variantName);
       config.variants[variantName] = {
         percentageSplit: row.Split,
-        pages: [new URL(row.Page.trim()).pathname],
+        pages: [new URL(row.Pages.trim()).pathname],
         label: row.Label,
       };
     });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -567,7 +567,6 @@ function decorateTemplateAndTheme() {
     const config = parseExperimentConfig(json);
     config.id = experimentId;
     config.manifest = path;
-    console.log(config);
     return config;
   } catch (e) {
     console.log(`error loading experiment manifest: ${path}`, e);
@@ -607,7 +606,6 @@ function getRandomVariant(config) {
  * @param {string} experimentId
  * @param {variant} variant
  */
-
  function saveSelectedExperimentVariant(experimentId, variant) {
   const experimentsStr = localStorage.getItem('hlx-experiments');
   const experiments = experimentsStr ? JSON.parse(experimentsStr) : {};
@@ -624,6 +622,24 @@ function getRandomVariant(config) {
 
   experiments[experimentId] = { variant, date };
   localStorage.setItem('hlx-experiments', JSON.stringify(experiments));
+}
+
+/**
+ * gets the variant id that this visitor has been assigned to if any
+ * @param {string} experimentId
+ * @return {string} assigned variant or empty string if none set
+ */
+
+ function getSavedExperimentVariant(experimentId) {
+  console.log('get last experiment', experimentId);
+  const experimentsStr = localStorage.getItem('hlx-experiments');
+  if (experimentsStr) {
+    const experiments = JSON.parse(experimentsStr);
+    if (experiments[experimentId]) {
+      return experiments[experimentId].variant;
+    }
+  }
+  return '';
 }
 
 /**
@@ -654,7 +670,7 @@ function getRandomVariant(config) {
       return;
     }
 
-    const forced = forcedVariant || getLastExperimentVariant(config.id);
+    const forced = forcedVariant || getSavedExperimentVariant(config.id);
     if (forced && config.variantNames.includes(forced)) {
       config.selectedVariant = forced;
     } else {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -641,6 +641,23 @@ function getRandomVariant(config) {
 }
 
 /**
+ * Replaces element with content from path
+ * @param {string} path
+ * @param {HTMLElement} element
+ */
+ async function replaceInner(path, element) {
+  const plainPath = `${path}.plain.html`;
+  try {
+    const resp = await fetch(plainPath);
+    const html = await resp.text();
+    element.innerHTML = html;
+  } catch (e) {
+    console.log(`error loading experiment content: ${plainPath}`, e);
+  }
+  return null;
+}
+
+/**
  * checks if a test is active on this page and if so executes the test
  */
  async function decorateExperiment() {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -505,7 +505,7 @@ function decorateTemplateAndTheme() {
   }
 
   // Get experiment from markup
-  return toClassName(getMeta('experiment'));
+  return toClassName(getMetadata('experiment'));
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -518,7 +518,7 @@ function decorateTemplateAndTheme() {
       variantNames: [],
     };
  */
- export async function parseExperimentConfig(json) {
+ export function parseExperimentConfig(json) {
   const config = {};
   try {
     json.settings.data.forEach((row) => {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -527,7 +527,7 @@ function decorateTemplateAndTheme() {
     
     config.variantNames = [];
     config.variants = {};
-    json.experiences.data.slice(1).forEach((row) => {
+    json.experiences.data.forEach((row) => {
       const variantName = toCamelCase(row.Name);
       config.variantNames.push(variantName);
       config.variants[variantName] = {
@@ -631,15 +631,13 @@ function getRandomVariant(config) {
  */
 
  function getSavedExperimentVariant(experimentId) {
-  console.log('get last experiment', experimentId);
   const experimentsStr = localStorage.getItem('hlx-experiments');
-  if (experimentsStr) {
-    const experiments = JSON.parse(experimentsStr);
-    if (experiments[experimentId]) {
-      return experiments[experimentId].variant;
-    }
+  if (!experimentsStr) {
+    return null;
   }
-  return '';
+
+  const experiments = JSON.parse(experimentsStr);
+  return experiments[experimentId] ? experiments[experimentId].variant : null;
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable no-console */
 
 /**
  * log RUM if part of the sample.
@@ -809,6 +810,7 @@ async function loadPage(doc) {
   loadDelayed(doc);
 
   if (window.location.hostname.endsWith('hlx.page') || window.location.hostname === ('localhost')) {
+    // eslint-disable-next-line import/no-cycle
     import('./experiment-preview.js');
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -490,7 +490,7 @@ function decorateTemplateAndTheme() {
  * Gets the experiment name, if any for the page based on env, useragent, queyr params
  * @returns {string} experimentid
  */
- export function getExperiment() {
+export function getExperiment() {
   // Non-prod website get default content
   // if (!window.location.host.includes('.hlx.live')) {
   //   return null;
@@ -518,7 +518,7 @@ function decorateTemplateAndTheme() {
       variantNames: [],
     };
  */
- export function parseExperimentConfig(json) {
+export function parseExperimentConfig(json) {
   const config = {};
   try {
     json.settings.data.forEach((row) => {
@@ -559,7 +559,7 @@ function decorateTemplateAndTheme() {
  * @param {string} experimentId
  * @returns {object} containing the experiment manifest
  */
- export async function getExperimentConfig(experimentId) {
+export async function getExperimentConfig(experimentId) {
   const path = `/experiments/${experimentId}/franklin-experiment.json`;
   try {
     const resp = await fetch(path);
@@ -583,7 +583,7 @@ function decorateTemplateAndTheme() {
  * @param {string} audience
  * @return {boolean} is member of this audience
  */
- function isValidAudience(audience) {
+function isValidAudience(audience) {
   if (audience === 'mobile') {
     return window.innerWidth < 600;
   }
@@ -610,7 +610,7 @@ function getRandomVariant(config) {
  * @param {string} experimentId
  * @param {variant} variant
  */
- function saveSelectedExperimentVariant(experimentId, variant) {
+function saveSelectedExperimentVariant(experimentId, variant) {
   const experimentsStr = localStorage.getItem('hlx-experiments');
   const experiments = experimentsStr ? JSON.parse(experimentsStr) : {};
 
@@ -634,7 +634,7 @@ function getRandomVariant(config) {
  * @return {string} assigned variant or empty string if none set
  */
 
- function getSavedExperimentVariant(experimentId) {
+function getSavedExperimentVariant(experimentId) {
   const experimentsStr = localStorage.getItem('hlx-experiments');
   if (!experimentsStr) {
     return null;
@@ -649,7 +649,7 @@ function getRandomVariant(config) {
  * @param {string} path
  * @param {HTMLElement} element
  */
- async function replaceInner(path, element) {
+async function replaceInner(path, element) {
   const plainPath = `${path}.plain.html`;
   try {
     const resp = await fetch(plainPath);
@@ -668,7 +668,7 @@ function getRandomVariant(config) {
 /**
  * checks if a test is active on this page and if so executes the test
  */
- async function decorateExperiment() {
+async function decorateExperiment() {
   try {
     const experiment = getExperiment();
     if (!experiment) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -643,7 +643,7 @@ function getRandomVariant(config) {
 /**
  * checks if a test is active on this page and if so executes the test
  */
- async function decorateTesting() {
+ async function decorateExperiment() {
   try {
     const experiment = getExperiment();
     if (!experiment) {
@@ -679,13 +679,13 @@ function getRandomVariant(config) {
     sampleRUM('experiment', { source: config.id, target: config.selectedVariant });
     console.debug(`running experiment (${window.hlx.experiment.id}) -> ${window.hlx.experiment.selectedVariant}`);
 
-    if (config.selectedVariant === 'control') {
+    if (config.selectedVariant === config.variantNames[0]) {
       return;
     }
 
     const currentPath = window.location.pathname;
-    const pageIndex = config.variants.control.pages.indexOf(currentPath);
-    console.debug(pageIndex, config.variants.control.pages, currentPath);
+    const pageIndex = config.variants[config.variantNames[0]].pages.indexOf(currentPath);
+    console.debug(pageIndex, config.variants[config.variantNames[0]].pages, currentPath);
     if (pageIndex < 0) {
       return;
     }
@@ -883,7 +883,7 @@ export function decorateMain(main) {
  */
 async function loadEager(doc) {
   decorateTemplateAndTheme();
-  await decorateTesting();
+  await decorateExperiment();
 
   const main = doc.querySelector('main');
   if (main) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -563,6 +563,10 @@ function decorateTemplateAndTheme() {
   const path = `/experiments/${experimentId}/franklin-experiment.json`;
   try {
     const resp = await fetch(path);
+    if (!resp.ok) {
+      console.log(`error loading experiment config:`, resp);
+      return null;
+    }
     const json = await resp.json();
     const config = parseExperimentConfig(json);
     config.id = experimentId;
@@ -649,6 +653,10 @@ function getRandomVariant(config) {
   const plainPath = `${path}.plain.html`;
   try {
     const resp = await fetch(plainPath);
+    if (!resp.ok) {
+      console.log(`error loading experiment content:`, resp);
+      return;
+    }
     const html = await resp.text();
     element.innerHTML = html;
   } catch (e) {

--- a/styles/experiment-preview.css
+++ b/styles/experiment-preview.css
@@ -200,7 +200,7 @@
 .hlx-preview-overlay-sidekick .hlx-popup {
   top: 58px;
   bottom: auto;
-  right: -22px;
+  right: -32px;
 }
 
 .hlx-preview-overlay-sidekick .hlx-popup::before {

--- a/styles/experiment-preview.css
+++ b/styles/experiment-preview.css
@@ -40,6 +40,7 @@
   border-radius: 100px;
   margin-left: 16px;
 }
+
 .hlx-badge .hlx-open::after {
   content: "";
   display: block;
@@ -82,10 +83,9 @@
 .hlx-popup .hlx-popup-header {
   display: flex;
   justify-content: space-between;
-  padding: 0 16px;
+  padding: 24px 16px;
   background-color: #222;
   border-radius: 16px 16px 0 0;
-  padding: 24px 16px;
 }
 
 .hlx-popup h4, .hlx-popup h5 {
@@ -144,10 +144,9 @@
   flex: 0 0 auto;
 }
 
-
-
 /* Overlay on sidekick if it is present */
-.hlx-preview-overlay--sidekick {
+
+.hlx-preview-overlay-sidekick {
   bottom: auto;
   right: 224px;
   top: 10px;
@@ -156,7 +155,7 @@
   z-index: 10000000;
 }
 
-.hlx-preview-overlay--sidekick .hlx-badge {
+.hlx-preview-overlay-sidekick .hlx-badge {
   background: none;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -165,28 +164,28 @@
   line-height: 1.2;
 }
 
-.hlx-preview-overlay--sidekick .hlx-badge:hover {
+.hlx-preview-overlay-sidekick .hlx-badge:hover {
   background-color: #909090;
   color: #303030;
 }
 
-.hlx-preview-overlay--sidekick .hlx-experiment-status-active {
+.hlx-preview-overlay-sidekick .hlx-experiment-status-active {
   background-color: #280;
 }
 
-.hlx-preview-overlay--sidekick .hlx-experiment-status-active:hover {
+.hlx-preview-overlay-sidekick .hlx-experiment-status-active:hover {
   background-color: #280;
   color: #dedede;
 }
 
-.hlx-preview-overlay--sidekick .hlx-open {
+.hlx-preview-overlay-sidekick .hlx-open {
   border: none;
   margin-left: 0;
   height: auto;
   width: 12px;
 }
 
-.hlx-preview-overlay--sidekick .hlx-open::after {
+.hlx-preview-overlay-sidekick .hlx-open::after {
   position: relative;
   transform: rotate(135deg);
   border-top: 1px solid;
@@ -198,13 +197,13 @@
   margin-left: 5px;
 }
 
-.hlx-preview-overlay--sidekick .hlx-popup {
+.hlx-preview-overlay-sidekick .hlx-popup {
   top: 58px;
   bottom: auto;
   right: -22px;
 }
 
-.hlx-preview-overlay--sidekick .hlx-popup::before {
+.hlx-preview-overlay-sidekick .hlx-popup::before {
   top: -15px;
   bottom: auto;
   border-top: none;

--- a/styles/experiment-preview.css
+++ b/styles/experiment-preview.css
@@ -23,11 +23,13 @@
   border-radius: 32px; 
   background-color: #888;
   color: #eee;
+  margin: 0;
   padding: 16px 32px;
   cursor: pointer;
   display: flex;
   align-items: center;
   position: relative;
+  font-size: inherit;
 }
 
 .hlx-badge .hlx-open {
@@ -146,61 +148,10 @@
 
 /* Overlay on sidekick if it is present */
 
-.hlx-preview-overlay-sidekick {
-  bottom: auto;
-  right: 224px;
-  top: 10px;
-  font-size: 14px;
-  font-weight: normal;
-  z-index: 10000000;
-}
-
-.hlx-preview-overlay-sidekick .hlx-badge {
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  padding: 5px 8px;
-  color: #dedede;
-  line-height: 1.2;
-}
-
-.hlx-preview-overlay-sidekick .hlx-badge:hover {
-  background-color: #909090;
-  color: #303030;
-}
-
-.hlx-preview-overlay-sidekick .hlx-experiment-status-active {
-  background-color: #280;
-}
-
-.hlx-preview-overlay-sidekick .hlx-experiment-status-active:hover {
-  background-color: #280;
-  color: #dedede;
-}
-
-.hlx-preview-overlay-sidekick .hlx-open {
-  border: none;
-  margin-left: 0;
-  height: auto;
-  width: 12px;
-}
-
-.hlx-preview-overlay-sidekick .hlx-open::after {
-  position: relative;
-  transform: rotate(135deg);
-  border-top: 1px solid;
-  border-right: 1px solid;
-  width: 7px;
-  height: 7px;
-  bottom: 2px;
-  left: 0;
-  margin-left: 5px;
-}
-
 .hlx-preview-overlay-sidekick .hlx-popup {
-  top: 58px;
+  position: fixed;
+  top: 68px;
   bottom: auto;
-  right: -32px;
 }
 
 .hlx-preview-overlay-sidekick .hlx-popup::before {

--- a/styles/experiment-preview.css
+++ b/styles/experiment-preview.css
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+.hlx-preview-overlay {
+  z-index: 99;
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  color: #eee;
+  font-weight: 600;
+  font-size: 24px;
+}
+
+.hlx-badge {
+  border-radius: 32px; 
+  background-color: #888;
+  color: #eee;
+  padding: 16px 32px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.hlx-badge .hlx-open {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  width: 22px;
+  height: 22px;
+  border: 2px solid;
+  border-radius: 100px;
+  margin-left: 16px;
+}
+.hlx-badge .hlx-open::after {
+  content: "";
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-top: 2px solid;
+  border-right: 2px solid;
+  transform: rotate(-45deg);
+  left: 6px;
+  bottom: 5px;
+}
+
+.hlx-badge.hlx-testing {
+  background-color: #fa0f00;
+  color: #fff;
+}
+
+.hlx-popup {
+  position: absolute;
+  bottom: 64px;
+  right: 0;
+  background-color: #444;
+  min-width: 300px;
+  border-radius: 16px;
+  box-shadow: 0 0 10px #000;
+  font-size: 12px;
+}
+
+.hlx-popup a:any-link {
+  color: #eee;
+  border: 2px solid;
+  padding: 5px 12px;
+  display: inline-block;
+  border-radius: 20px;
+  text-decoration: none;
+}
+
+.hlx-popup .hlx-popup-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 16px;
+  background-color: #222;
+  border-radius: 16px 16px 0 0;
+  padding: 24px 16px;
+}
+
+.hlx-popup h4, .hlx-popup h5 {
+  margin: 0;
+}
+
+.hlx-popup h4 {
+  font-size: 16px;
+}
+
+.hlx-popup h5 {
+  font-size: 14px;
+}
+
+
+.hlx-popup p {
+  margin: 0;
+}
+
+.hlx-popup::before {
+  content: '';
+  width: 0;
+  height: 0;
+  position: absolute;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;    
+  border-top: 15px solid #444;
+  bottom: -15px;
+  right: 30px;
+}
+
+.hlx-hidden {
+  display: none;
+}
+
+.hlx-badge.hlx-experiment-status-active {
+  background-color: #280;
+}
+
+.hlx-variant {
+  margin: 16px;
+  display: flex;
+  padding: 16px;
+  border-radius: 16px;
+}
+
+.hlx-variant-selected {
+  background-color: #666;
+}
+
+.hlx-variant > div {
+  flex: 1 1 auto;
+}
+
+.hlx-variant > div.hlx-button {
+  flex: 0 0 auto;
+}
+
+
+
+/* Overlay on sidekick if it is present */
+.hlx-preview-overlay--sidekick {
+  bottom: auto;
+  right: 224px;
+  top: 10px;
+  font-size: 14px;
+  font-weight: normal;
+  z-index: 10000000;
+}
+
+.hlx-preview-overlay--sidekick .hlx-badge {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: #dedede;
+  line-height: 1.2;
+}
+
+.hlx-preview-overlay--sidekick .hlx-badge:hover {
+  background-color: #909090;
+  color: #303030;
+}
+
+.hlx-preview-overlay--sidekick .hlx-experiment-status-active {
+  background-color: #280;
+}
+
+.hlx-preview-overlay--sidekick .hlx-experiment-status-active:hover {
+  background-color: #280;
+  color: #dedede;
+}
+
+.hlx-preview-overlay--sidekick .hlx-open {
+  border: none;
+  margin-left: 0;
+  height: auto;
+  width: 12px;
+}
+
+.hlx-preview-overlay--sidekick .hlx-open::after {
+  position: relative;
+  transform: rotate(135deg);
+  border-top: 1px solid;
+  border-right: 1px solid;
+  width: 7px;
+  height: 7px;
+  bottom: 2px;
+  left: 0;
+  margin-left: 5px;
+}
+
+.hlx-preview-overlay--sidekick .hlx-popup {
+  top: 58px;
+  bottom: auto;
+  right: -22px;
+}
+
+.hlx-preview-overlay--sidekick .hlx-popup::before {
+  top: -15px;
+  bottom: auto;
+  border-top: none;
+  border-bottom: 15px solid #222;
+}


### PR DESCRIPTION
## Use case

As a content author, I want to be able to define basic A/B Test experiments and have my users be served a random variant of the content as needed.

## Technical

A new experiment needs to be defined in: https://drive.google.com/drive/u/3/folders/14gxnAYlA4kUGmIlIh4rfYNJOBO_F_Wy3
And its details need to be specified in:
https://docs.google.com/spreadsheets/d/1PP1ECWDsOK1GWwE6Y35e4mFdGZDO_C2own3e9NBc0Dw/edit
The variants are just plain documents in the same folder

The pages that we want to have the experiment on also need to define a `Metadata` block with the `Experiment` property set to the experiment folder name above.

On page load, the JS will read the `experiment` property from the meta tag in the `<head>`, then randomly choose one of the experiments defined in the sheet based on the percentage split, and finally request the matching URL and inline it in the `<body>` of the page.

## UX

Page annotated with experiment metadata:
<img width="688" alt="Screen Shot 2022-09-22 at 10 56 34 AM" src="https://user-images.githubusercontent.com/1235810/191704080-4697ce53-80ae-45c3-b170-8e3f5397071c.png">

Experiment definition:
<img width="1040" alt="Screen Shot 2022-09-22 at 10 51 49 AM" src="https://user-images.githubusercontent.com/1235810/191702953-9e2a7a1b-8c65-4e71-ba43-91a18a584516.png">

Experiment toggle on the sidekick:
<img width="1279" alt="Screen Shot 2022-09-22 at 10 50 27 AM" src="https://user-images.githubusercontent.com/1235810/191702701-a0c6448b-d71d-4eed-ad9c-a3ea88a68b62.png">

## Demo
Test URLs:
- Before: https://main--aldi-nord-recipes--hlxsites.hlx.page/
- After:
    - https://sites-8211--aldi-nord-recipes--hlxsites.hlx.page/
    - https://sites-8211--aldi-nord-recipes--hlxsites.hlx.page/?experiment=vegi-menu/variant-a (for a forced variant)

Fix SITES-8211, SITES-8212