### PR TITLE
feat: add support for marketing campaigns via URL parameter

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -488,6 +488,53 @@ function decorateTemplateAndTheme() {
 }
 
 /**
+ * Replaces element with content from path
+ * @param {string} path
+ * @param {HTMLElement} element
+ */
+async function replaceInner(path, element) {
+  const plainPath = `${path}.plain.html`;
+  try {
+    const resp = await fetch(plainPath);
+    if (!resp.ok) {
+      console.log('error loading experiment content:', resp);
+      return null;
+    }
+    const html = await resp.text();
+    element.innerHTML = html;
+  } catch (e) {
+    console.log(`error loading experiment content: ${plainPath}`, e);
+  }
+  return null;
+}
+
+async function decorateCampaign() {
+  try {
+    const campaigns = getMetadata('campaigns').split(',').map((c) => toClassName(c.trim()));
+    if (!campaigns.length) {
+      return null;
+    }
+
+    const usp = new URLSearchParams(window.location.search);
+    const campaign = usp.get('campaign');
+    if (!campaign || !campaigns.includes(campaign)) {
+      return null;
+    }
+
+    const campaignsPath = '/campaigns';
+    const campaignPath = new URL(`${window.hlx.codeBasePath}${campaignsPath}/${campaign}`, window.location.href).pathname;
+    const currentPath = window.location.pathname;
+    if (campaignPath && campaignPath !== currentPath) {
+      await replaceInner(campaignPath, document.querySelector('main'));
+    }
+    return campaign;
+  } catch (e) {
+    console.log('error testing', e);
+  }
+  return null;
+}
+
+/**
  * Gets the experiment name, if any for the page based on env, useragent, queyr params
  * @returns {string} experimentid
  */
@@ -643,27 +690,6 @@ function getSavedExperimentVariant(experimentId) {
 
   const experiments = JSON.parse(experimentsStr);
   return experiments[experimentId] ? experiments[experimentId].variant : null;
-}
-
-/**
- * Replaces element with content from path
- * @param {string} path
- * @param {HTMLElement} element
- */
-async function replaceInner(path, element) {
-  const plainPath = `${path}.plain.html`;
-  try {
-    const resp = await fetch(plainPath);
-    if (!resp.ok) {
-      console.log('error loading experiment content:', resp);
-      return null;
-    }
-    const html = await resp.text();
-    element.innerHTML = html;
-  } catch (e) {
-    console.log(`error loading experiment content: ${plainPath}`, e);
-  }
-  return null;
 }
 
 /**
@@ -913,7 +939,10 @@ export function decorateMain(main) {
  */
 async function loadEager(doc) {
   decorateTemplateAndTheme();
-  await decorateExperiment();
+  const campaign = await decorateCampaign();
+  if (!campaign) {
+    await decorateExperiment();
+  }
 
   const main = doc.querySelector('main');
   if (main) {


### PR DESCRIPTION
## Use case
As a business practitioner, I want to be able to send out email campaigns to my customer with links to my website that directly point to the matching product campaign.

## Technical

A new campaign needs to be created in https://drive.google.com/drive/u/3/folders/1v-Am8JAc-epuZqCvri6AHOW2zavLF2am
The name of the file will serve as campaign identifier.

The pages that we want to have the campaign on also need to define a Metadata block with the Campaigns comma-separated list property set and containing the campaign identifier above.

On page load, the JS will read the `campaigns` property from the meta tag in the `<head>` and the `campaign` query parameter from the URL. If the query parameter matches one of the campaigns supported by the page, we then request the matching URL and inline it in the `<body>` of the page.

:warning: The campaign takes precedence over the experiments defined in #1.

## UX

<img width="692" alt="Screen Shot 2022-09-23 at 3 55 28 PM" src="https://user-images.githubusercontent.com/1235810/191976894-fcff688e-3c49-4bf1-ae79-5b2c01c444bc.png">

Test URLs:
- Before: https://main--aldi-nord-recipes--hlxsites.hlx.page/
- After: https://sites-8213--aldi-nord-recipes--hlxsites.hlx.page/?campaign=greenlover

Fix SITES-8213